### PR TITLE
Renames

### DIFF
--- a/ServoTimer2.cpp
+++ b/ServoTimer2.cpp
@@ -11,10 +11,10 @@ static void writeChan(uint8_t chan, int pulsewidth);
 
 #define FRAME_SYNC_INDEX   0		 // frame sync delay is the first entry in the channel array
 #define FRAME_SYNC_PERIOD  20000	   // total frame duration in microseconds 
-#define FRAME_SYNC_DELAY   ((FRAME_SYNC_PERIOD - ( NBR_CHANNELS * DEFAULT_PULSE_WIDTH))/ 128) // number of iterations of the ISR to get the desired frame rate
+#define FRAME_SYNC_DELAY   ((FRAME_SYNC_PERIOD - ( NBR_CHANNELS * DEFAULT_PULSE_WIDTH_T2))/ 128) // number of iterations of the ISR to get the desired frame rate
 #define DELAY_ADJUST	 8		 // number of microseconds of calculation overhead to be subtracted from pulse timings   
 
-static servo_t servos[NBR_CHANNELS+1];    // static array holding servo data for all channels
+static servo2_t servos2[NBR_CHANNELS+1];    // static array holding servo data for all channels
 
 static volatile uint8_t Channel;   // counter holding the channel being pulsed
 static volatile uint8_t ISRCount;  // iteration counter used in the interrupt routines;
@@ -24,22 +24,22 @@ static boolean isStarted = false;  // flag to indicate if the ISR has been initi
 ISR (TIMER2_OVF_vect)
 { 
   ++ISRCount; // increment the overlflow counter
-  if (ISRCount ==  servos[Channel].counter ) // are we on the final iteration for this channel
+  if (ISRCount ==  servos2[Channel].counter ) // are we on the final iteration for this channel
   {
-	TCNT2 =  servos[Channel].remainder;   // yes, set count for overflow after remainder ticks
+	TCNT2 =  servos2[Channel].remainder;   // yes, set count for overflow after remainder ticks
   }  
-  else if(ISRCount >  servos[Channel].counter)  
+  else if(ISRCount >  servos2[Channel].counter)  
   {
 	// we have finished timing the channel so pulse it low and move on
-	if(servos[Channel].Pin.isActive == true)	     // check if activated
-	    digitalWrite( servos[Channel].Pin.nbr,LOW); // pulse this channel low if active   
+	if(servos2[Channel].Pin.isActive == true)	     // check if activated
+	    digitalWrite( servos2[Channel].Pin.nbr,LOW); // pulse this channel low if active   
 
 	  Channel++;    // increment to the next channel
 	ISRCount = 0; // reset the isr iteration counter 
 	TCNT2 = 0;    // reset the clock counter register
 	if( (Channel != FRAME_SYNC_INDEX) && (Channel <= NBR_CHANNELS) ){	     // check if we need to pulse this channel    
-	    if(servos[Channel].Pin.isActive == true)	   // check if activated
-		 digitalWrite( servos[Channel].Pin.nbr,HIGH); // its an active channel so pulse it high   
+	    if(servos2[Channel].Pin.isActive == true)	   // check if activated
+		 digitalWrite( servos2[Channel].Pin.nbr,HIGH); // its an active channel so pulse it high   
 	}
 	else if(Channel > NBR_CHANNELS){ 
 	   Channel = 0; // all done so start over		   
@@ -63,15 +63,15 @@ uint8_t ServoTimer2::attach(int pin)
 	{
 	 //debug("attaching chan = ", chanIndex);
 	 pinMode( pin, OUTPUT) ;  // set servo pin to output
-	 servos[this->chanIndex].Pin.nbr = pin;  
-	 servos[this->chanIndex].Pin.isActive = true;  
+	 servos2[this->chanIndex].Pin.nbr = pin;  
+	 servos2[this->chanIndex].Pin.isActive = true;  
 	} 
 	return this->chanIndex ;
 }
 
 void ServoTimer2::detach()  
 {
-    servos[this->chanIndex].Pin.isActive = false;  
+    servos2[this->chanIndex].Pin.isActive = false;  
 }
 
 void ServoTimer2::write(int pulsewidth)
@@ -83,7 +83,7 @@ int ServoTimer2::read()
 {
   unsigned int pulsewidth;
    if( this->chanIndex > 0)
-	pulsewidth =  servos[this->chanIndex].counter * 128 + ((255 - servos[this->chanIndex].remainder) / 2) + DELAY_ADJUST ;
+	pulsewidth =  servos2[this->chanIndex].counter * 128 + ((255 - servos2[this->chanIndex].remainder) / 2) + DELAY_ADJUST ;
    else 
 	 pulsewidth  = 0;
    return pulsewidth;   
@@ -91,7 +91,7 @@ int ServoTimer2::read()
  
 boolean ServoTimer2::attached()
 {
-    return servos[this->chanIndex].Pin.isActive ;
+    return servos2[this->chanIndex].Pin.isActive ;
 }
 
 static void writeChan(uint8_t chan, int pulsewidth)
@@ -99,23 +99,23 @@ static void writeChan(uint8_t chan, int pulsewidth)
    // calculate and store the values for the given channel
    if( (chan > 0) && (chan <= NBR_CHANNELS) )   // ensure channel is valid
    { 
-	if( pulsewidth < MIN_PULSE_WIDTH )		    // ensure pulse width is valid
-	    pulsewidth = MIN_PULSE_WIDTH;
-	else if( pulsewidth > MAX_PULSE_WIDTH )
-	    pulsewidth = MAX_PULSE_WIDTH;	 
+	if( pulsewidth < MIN_PULSE_WIDTH_T2 )		    // ensure pulse width is valid
+	    pulsewidth = MIN_PULSE_WIDTH_T2;
+	else if( pulsewidth > MAX_PULSE_WIDTH_T2 )
+	    pulsewidth = MAX_PULSE_WIDTH_T2;	 
 	
 	  pulsewidth -=DELAY_ADJUST;			 // subtract the time it takes to process the start and end pulses (mostly from digitalWrite) 
-	servos[chan].counter = pulsewidth / 128;	
-	servos[chan].remainder = 255 - (2 * (pulsewidth - ( servos[chan].counter * 128)));  // the number of 0.5us ticks for timer overflow	   
+	servos2[chan].counter = pulsewidth / 128;	
+	servos2[chan].remainder = 255 - (2 * (pulsewidth - ( servos2[chan].counter * 128)));  // the number of 0.5us ticks for timer overflow	   
    }
 }
 
 static void initISR()
 {   
 	for(uint8_t i=1; i <= NBR_CHANNELS; i++) {  // channels start from 1    
-	   writeChan(i, DEFAULT_PULSE_WIDTH);  // store default values	    
+	   writeChan(i, DEFAULT_PULSE_WIDTH_T2);  // store default values	    
 	}
-	servos[FRAME_SYNC_INDEX].counter = FRAME_SYNC_DELAY;   // store the frame sync period	 
+	servos2[FRAME_SYNC_INDEX].counter = FRAME_SYNC_DELAY;   // store the frame sync period	 
 
 	Channel = 0;  // clear the channel index  
 	ISRCount = 0;  // clear the value of the ISR counter;

--- a/ServoTimer2.h
+++ b/ServoTimer2.h
@@ -76,11 +76,11 @@ The pulse width timing is accurate to within 1%
 //typedef uint8_t boolean;
 //typedef uint8_t byte;
 
-#define MIN_PULSE_WIDTH       750        // the shortest pulse sent to a servo  
+#define MIN_PULSE_WIDTH_T2       750        // the shortest pulse sent to a servo  
 
-#define MAX_PULSE_WIDTH      2250        // the longest pulse sent to a servo 
+#define MAX_PULSE_WIDTH_T2      2250        // the longest pulse sent to a servo 
 
-#define DEFAULT_PULSE_WIDTH  1500        // default pulse width when servo is attached
+#define DEFAULT_PULSE_WIDTH_T2  1500        // default pulse width when servo is attached
 
 #define FRAME_SYNC_PERIOD   20000        // total frame duration in microseconds 
 
@@ -92,19 +92,19 @@ typedef struct  {
 
       uint8_t isActive   :1 ;  // false if this channel not enabled, pin only pulsed if true 
 
-   } ServoPin_t   ;  
+   } ServoPin2_t   ;  
 
 
 
 typedef struct {
 
-  ServoPin_t Pin;
+  ServoPin2_t Pin;
 
   byte counter;
 
   byte remainder;
 
-}  servo_t;
+}  servo2_t;
 
 class ServoTimer2
 {


### PR DESCRIPTION
ServoTimer2 uses some definitions and the struct servo_t that are also available in <servo.h>. This creates conflicts and makes a simultaneous include impossible. This renames solve the problem without changes anythink into the logic.